### PR TITLE
fix the variable check and add new recipes for vader cookbook

### DIFF
--- a/src/Geometry.cc
+++ b/src/Geometry.cc
@@ -138,6 +138,7 @@ Geometry::Geometry(const eckit::Configuration & config,
     for(std::map<std::string,std::string>::iterator it = group.mapVariables_.begin(); it != group.mapVariables_.end(); ++it) {
       oops::Log::info() << it->first << " -> " << it->second << std::endl;
       groupIndex_[it->first] = groupIndex;
+      groupIndex_[it->second] = groupIndex;
     }
 
     // Number of levels

--- a/src/VaderCookbook.h
+++ b/src/VaderCookbook.h
@@ -23,8 +23,14 @@ namespace genint {
       {{"potential_temperature",        {"AirPotentialTemperature_B"}},
       // P: from delp, from ps (and ak/bk)
       {"air_pressure_levels",          {"AirPressureAtInterface_B", "AirPressureAtInterface_A"}},
+      // t: from p-pt and pt-base, from pt
+      {"air_temperature",              {"AirTemperature_C", "AirTemperature_A"}},
       // p: from pe
       {"air_pressure",                 {"AirPressure_A"}},
+      // rh: 
+      {"relative_humidity",            {"RelativeHumidity_B"}},
+      // mr: from spfh
+      {"humidity_mixing_ratio",        {"HumidityMixingRatio_A"}},
       // ln(p) from pe
       {"ln_air_pressure_at_interface", {"LnAirPressureAtInterface_A"}},
       // p^kappa from pe and ln(p)


### PR DESCRIPTION
Now it creates the groupIndex_ array for model variable names and mapped jedi names.
It can resolve the error when JEDI is looking for the variable in `map jedi name`.

I also add several new Vader recipes.

