### PR TITLE
Updates for wrfchem

### DIFF
--- a/src/Constants.cc
+++ b/src/Constants.cc
@@ -21,6 +21,7 @@ namespace genint {
     static const double grav           = 9.80665;
     static const double airmw          = 28.965;
     static const double h2omw          = 18.015;
+    static const double sulfmw         = 96.06;
     static const double runiv          = 8314.47;
     static const double rdry           = runiv/airmw;
     static const double cpdry          = 3.5*rdry;
@@ -41,6 +42,7 @@ namespace genint {
         {"grav", grav},
         {"airmw", airmw},
         {"h2omw", h2omw},
+        {"sulfmw", sulfmw},
         {"runiv", runiv},
         {"rdry", rdry},
         {"cpdry", cpdry},

--- a/src/Fields.cc
+++ b/src/Fields.cc
@@ -752,7 +752,8 @@ void Fields::print(std::ostream & os) const {
   }
   os << prefix << "Fields:";
   const auto ghostView = atlas::array::make_view<int, 1>(geom_->functionSpace().ghost());
-  for (const auto & var : vars_.variables()) {
+  for (const auto & var : fset_.field_names()) {
+  // for (const auto & var : vars_.variables()) {
     const auto gmaskView = atlas::array::make_view<int, 2>(
       geom_->fields(geom_->groupIndex(var)).field("gmask"));
     os << std::endl;

--- a/src/Geometry.cc
+++ b/src/Geometry.cc
@@ -153,6 +153,18 @@ Geometry::Geometry(const eckit::Configuration & config,
     // Top Pressure
     group.pTop_ = groupParams.pTop.value();
 
+    // Level Top Down
+    group.levTopDown_ = groupParams.levTopDown.value();
+
+    // Base air potential temperature
+    const boost::optional<double> &pt_base = groupParams.baseTheta.value();
+    if (pt_base != boost::none) {
+      group.baseTheta_ = *pt_base; 
+    } else {
+      group.baseTheta_ = 0.;
+    }
+    oops::Log::debug() << "base theta= " << group.baseTheta_ << std::endl;
+
     // Sigma pressure coefficients
     if (group.verticalCoordinate_ == "akbk"){
       const boost::optional<std::vector<double>> &akParams = groupParams.ak.value();
@@ -336,6 +348,12 @@ Geometry::Geometry(const Geometry & other) : comm_(other.comm_), halo_(other.hal
 
     // top level
     group.pTop_ = other.groups_[groupIndex].pTop_;
+
+    // Level Top Down
+    group.levTopDown_ = other.groups_[groupIndex].levTopDown_;
+
+    // base air potential temperature
+    group.baseTheta_ = other.groups_[groupIndex].baseTheta_;
 
     // Copy corresponding level for 2D variables (first or last)
     group.lev2d_ = other.groups_[groupIndex].lev2d_;

--- a/src/Geometry.cc
+++ b/src/Geometry.cc
@@ -153,6 +153,15 @@ Geometry::Geometry(const eckit::Configuration & config,
     // Top Pressure
     group.pTop_ = groupParams.pTop.value();
 
+    // Base air potential temperature
+    const boost::optional<double> &pt_base = groupParams.baseTheta.value();
+    if (pt_base != boost::none) {
+      group.baseTheta_ = *pt_base; 
+    } else {
+      group.baseTheta_ = 0.;
+    }
+    oops::Log::debug() << "base theta= " << group.baseTheta_ << std::endl;
+
     // Sigma pressure coefficients
     if (group.verticalCoordinate_ == "akbk"){
       const boost::optional<std::vector<double>> &akParams = groupParams.ak.value();
@@ -336,6 +345,9 @@ Geometry::Geometry(const Geometry & other) : comm_(other.comm_), halo_(other.hal
 
     // top level
     group.pTop_ = other.groups_[groupIndex].pTop_;
+
+    // base air potential temperature
+    group.baseTheta_ = other.groups_[groupIndex].baseTheta_;
 
     // Copy corresponding level for 2D variables (first or last)
     group.lev2d_ = other.groups_[groupIndex].lev2d_;

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -69,6 +69,12 @@ class GroupParameters : public oops::Parameters {
   /// Mask path
   oops::Parameter<std::string> maskPath{"mask path", "../genint/data/landsea.nc", this};
 
+  // Base Potential Temperature
+  oops::OptionalParameter<double> baseTheta{"base theta", this};
+
+  // Levels Top-down
+  oops::Parameter<bool> levTopDown{"level top down", "true", this};
+
 };
 
 // -----------------------------------------------------------------------------
@@ -131,7 +137,7 @@ class Geometry : public util::Printable,
   size_t maskLevel(const std::string &, const size_t &) const;
   std::vector<size_t> variableSizes(const oops::Variables & vars) const;
   void latlon(std::vector<double> &, std::vector<double> &, const bool) const;
-  bool levelsAreTopDown() const {return true;}
+  bool levelsAreTopDown() const {return groups_[0].levTopDown_;}
 
   // Functions to retrieve geometry features
   const std::vector<double> & ak() const {return groups_[0].ak_;}
@@ -166,6 +172,7 @@ class Geometry : public util::Printable,
     std::map<std::string,std::string> mapVariables_;
     atlas::FieldSet fields_;
     double gmaskSize_;
+    bool levTopDown_;
   };
   std::vector<groupData> groups_;
 };

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -73,7 +73,7 @@ class GroupParameters : public oops::Parameters {
   oops::OptionalParameter<double> baseTheta{"base theta", this};
 
   // Levels Top-down
-  oops::Parameter<bool> levTopDown{"level top down", "true", this};
+  oops::Parameter<bool> levTopDown{"level top down", true, this};
 
 };
 

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -143,6 +143,7 @@ class Geometry : public util::Printable,
   const std::vector<double> & ak() const {return groups_[0].ak_;}
   const std::vector<double> & bk() const {return groups_[0].bk_;}
   const double & pTop() const {return groups_[0].pTop_;}
+  const double & baseTheta() const {return groups_[0].baseTheta_;}
   const size_t & levels() const {return groups_[0].levels_;}
 
   // Mapping io var to jedi names
@@ -169,6 +170,7 @@ class Geometry : public util::Printable,
     std::vector<double> ak_;
     std::vector<double> bk_;
     double pTop_;
+    double baseTheta_;
     std::map<std::string,std::string> mapVariables_;
     atlas::FieldSet fields_;
     double gmaskSize_;

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -69,6 +69,9 @@ class GroupParameters : public oops::Parameters {
   /// Mask path
   oops::Parameter<std::string> maskPath{"mask path", "../genint/data/landsea.nc", this};
 
+  // Base Potential Temperature
+  oops::OptionalParameter<double> baseTheta{"base theta", this};
+
 };
 
 // -----------------------------------------------------------------------------
@@ -138,6 +141,7 @@ class Geometry : public util::Printable,
   const std::vector<double> & bk() const {return groups_[0].bk_;}
   const double & pTop() const {return groups_[0].pTop_;}
   const size_t & levels() const {return groups_[0].levels_;}
+  const double & baseTheta() const {return groups_[0].baseTheta_;}
 
   // Mapping io var to jedi names
   std::map<std::string,std::string> mapVariables() const;
@@ -163,6 +167,7 @@ class Geometry : public util::Printable,
     std::vector<double> ak_;
     std::vector<double> bk_;
     double pTop_;
+    double baseTheta_;
     std::map<std::string,std::string> mapVariables_;
     atlas::FieldSet fields_;
     double gmaskSize_;

--- a/src/ModelData.cc
+++ b/src/ModelData.cc
@@ -26,7 +26,8 @@ ModelData::ModelData(const Geometry & geometry) :
     ak_(geometry.ak()),
     bk_(geometry.bk()),
     nLevels_(geometry.levels()),
-    pTop_(geometry.pTop()) {}
+    pTop_(geometry.pTop()),
+    baseTheta_(geometry.baseTheta()) {}
 
 // -------------------------------------------------------------------------------------------------
 
@@ -47,6 +48,7 @@ const eckit::LocalConfiguration ModelData::modelData() const {
   modelData.set("sigma_pressure_hybrid_coordinate_a_coefficient", ak_);
   modelData.set("sigma_pressure_hybrid_coordinate_b_coefficient", bk_);
   modelData.set("nLevels", nLevels_);
+  modelData.set("base_air_potential_temperature", baseTheta_);
 
   return modelData;
 }

--- a/src/ModelData.h
+++ b/src/ModelData.h
@@ -32,6 +32,7 @@ class ModelData : public util::Printable {
   const std::vector<double> bk_;
   const int nLevels_;
   const double pTop_;
+  const double baseTheta_;
 };
 
 // -------------------------------------------------------------------------------------------------

--- a/src/State.cc
+++ b/src/State.cc
@@ -45,6 +45,7 @@ State::State(const Geometry & resol, const eckit::Configuration & file)
   }
   const util::DateTime vt(file.getString("date"));
   fields_->time() = vt;
+  // this->print(oops::Log::info());
   oops::Log::trace() << "State::State created." << std::endl;
 }
 // -----------------------------------------------------------------------------

--- a/src/VaderCookbook.h
+++ b/src/VaderCookbook.h
@@ -30,9 +30,19 @@ namespace genint {
       // rh: 
       {"relative_humidity",            {"RelativeHumidity_B"}},
       // mr: from spfh
-      {"humidity_mixing_ratio",        {"HumidityMixingRatio_A"}},
+      {"humidity_mixing_ratio",        {"HumidityMixingRatio_A", "HumidityMixingRatio_B"}},
+      // sulfmf: 
+      {"mass_fraction_of_sulfate_in_air",  {"SulfateMassFraction_A"}},
+      // spfh: from mr
+      {"specific_humidity",            {"SpecificHumidity_A"}},
       // ln(p) from pe
       {"ln_air_pressure_at_interface", {"LnAirPressureAtInterface_A"}},
+      // qsat
+      {"qsat",                         {"SaturationSpecificHumidity_A"}},
+      // svp
+      {"svp",                          {"SaturationVaporPressure_A"}},
+      // dlsvpdT
+      {"dlsvpdT",                      {"LogDerivativeSaturationVaporPressure_A"}},
       // p^kappa from pe and ln(p)
       {"air_pressure_to_kappa",        {"AirPressureToKappa_A"}},
       // delp: from p

--- a/src/VaderCookbook.h
+++ b/src/VaderCookbook.h
@@ -25,12 +25,14 @@ namespace genint {
       {"air_pressure_levels",          {"AirPressureAtInterface_B", "AirPressureAtInterface_A"}},
       // t: from p-pt and pt-base, from pt
       {"air_temperature",              {"AirTemperature_C", "AirTemperature_A"}},
-      // p: from pe
-      {"air_pressure",                 {"AirPressure_A"}},
+      // p: from pe, from p-p and p-base
+      {"air_pressure",                 {"AirPressure_A", "AirPressure_B"}},
       // rh: 
-      {"relative_humidity",            {"RelativeHumidity_B"}},
+      {"relative_humidity",            {"RelativeHumidity_A"}},
       // mr: from spfh
       {"humidity_mixing_ratio",        {"HumidityMixingRatio_A"}},
+      // spfh: from mr
+      {"specific_humidity",            {"SpecificHumidity_A"}},
       // ln(p) from pe
       {"ln_air_pressure_at_interface", {"LnAirPressureAtInterface_A"}},
       // p^kappa from pe and ln(p)

--- a/src/VariableChange.cc
+++ b/src/VariableChange.cc
@@ -39,11 +39,16 @@ VariableChange::VariableChange(const eckit::Configuration & config, const Geomet
   VariableChangeParameters params;
   params.deserialize(config);
   eckit::LocalConfiguration variableChangeConfig = params.toConfiguration();
+
+  oops::Log::debug() << "variableChangeConfig config: " << variableChangeConfig << std::endl;
+
   ModelData modelData{geometry};
   eckit::LocalConfiguration vaderConfig;
   vaderConfig.set(vader::configCookbookKey,
                                 variableChangeConfig.getSubConfiguration("vader custom cookbook"));
   vaderConfig.set(vader::configModelVarsKey, modelData.modelData());
+
+  oops::Log::debug() << "Vader config: " << vaderConfig << std::endl;
 
   // Create vader with genint custom cookbook
   vader_.reset(new vader::Vader(params.vaderParam,

--- a/src/VariableChange.cc
+++ b/src/VariableChange.cc
@@ -65,7 +65,7 @@ void VariableChange::changeVar(State & x, const oops::Variables & vars_out) cons
 
   // Needed Variables and fieldsets copies
   oops::Variables varsCha = vars_out;
-  oops::Variables varsState =  x.variables();
+  oops::Variables varsState = x.variables();
   oops::Variables varsAdd = x.variables();
   atlas::FieldSet xfs;
   x.toFieldSet(xfs);
@@ -95,7 +95,10 @@ void VariableChange::changeVar(State & x, const oops::Variables & vars_out) cons
   for (auto &var : varsAdd.variables()) {
     xfsOut.add(xfs.field(var));
   }
+
   x.fromFieldSet(xfsOut);
+  oops::Log::info() << "x from xfsOut:" << std::endl;
+  oops::Log::info() << x << std::endl;
 
   oops::Log::trace() << "VariableChange::changeVar done" << std::endl;
 }

--- a/src/VariableChange.cc
+++ b/src/VariableChange.cc
@@ -97,8 +97,6 @@ void VariableChange::changeVar(State & x, const oops::Variables & vars_out) cons
   }
 
   x.fromFieldSet(xfsOut);
-  oops::Log::info() << "x from xfsOut:" << std::endl;
-  oops::Log::info() << x << std::endl;
 
   oops::Log::trace() << "VariableChange::changeVar done" << std::endl;
 }

--- a/test/testinput/hofx3d_lambertCC.yaml
+++ b/test/testinput/hofx3d_lambertCC.yaml
@@ -51,6 +51,8 @@ geometry:
 
     levels: 42
     top pressure: 50
+    base theta: 290.
+    level top down: false
   - map jedi names:
       air_pressure_levels: air_pressure_levels
     levels: 43


### PR DESCRIPTION
Updates for WRF-Chem use case.
1. add the `level top down` key (required) to identify the model is top-down or bottom-up.
2. add the `base theta` key (optional) to define the base potential temperature used in WRF
3. add new recipe to convert units of water vapor mixing ratio from kg/kg to g/kg (need a PR in Vader)
4. add new recipe to convert sulfate in ppmv to ug/kg (need a PR in Vader)
5. add new recipe to convert perturbation theta to theta (need a PR in Vader)
6. add new recipes to calculate specific humidity, relative humidity and its ingredients. 